### PR TITLE
add: Menu Drawer & Many Pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,29 @@
 import * as React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, DrawerActions} from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { Image } from 'react-native';
-import {theme} from './theme';
+import { createDrawerNavigator } from '@react-navigation/drawer';
+import { Image, Dimensions } from 'react-native';
+import { theme } from './theme';
 
 import MainScreen from './MainScreen';
-import SelectScreen from './SelectScreen';
+import SelectScreen from './screens/SelectScreen';
 import ViewAll from './ViewAllScreen';
+import Completed from './screens/CompletedScreen';
+import Uncompleted from './screens/UncompletedScreen'; 
+import Daily from './screens/DailyScreen';
+import Monthly from './screens/monthlyScreen';
+import CompletionRate from './screens/CompletionRateScreen';
 
 //change screen using navigation stack&tab
 const Stack = createStackNavigator();
-const Tab = createBottomTabNavigator();
-
-//onPress={()=>NavigationContainer.push()}
+const Tab = createBottomTabNavigator(); 
+const Drawer = createDrawerNavigator();
 
 //BottomTab
 function BottomTab(){
   return(
-    <Tab.Navigator initalRouteName="TAB" drawerPosition="bottom">
+    <Tab.Navigator initalRouteName="MAIN" drawerPosition="bottom">
         <Tab.Screen name="ViewAll" component={ViewAll} 
         options={{headerShown:false, //delete headear
         tabBarInactiveBackgroundColor:theme.background,
@@ -28,8 +33,8 @@ function BottomTab(){
           const image = focused ? require('../assets/list.png') : require('../assets/list.png')
           return (<Image source={image} style={{width:30, height:24}}/>)
         }}}/> 
-        <Tab.Screen name="Home" component={MainScreen}
-        options={{headerShown:false, 
+        <Tab.Screen name="MAIN" component={MainScreen}
+        options={{ headerShown:false,
         tabBarInactiveBackgroundColor:theme.background, 
         tabBarActiveBackgroundColor:theme.background,
         tabBarActiveTintColor:"#778bdd",
@@ -41,19 +46,172 @@ function BottomTab(){
   )
 }
 
+
+/*
+function completed({ navigation }) {
+  return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Button title="completed" />
+      </View>
+  );
+}
+*/
+
+function MenuBar() {
+  var now = new Date();
+  var month = now.getMonth() + 1;
+  var today = now.getDate();
+
+  return(
+          <Drawer.Navigator initialRouteName="MAIN">
+              <Drawer.Screen 
+                  name="main" 
+                  component={MainScreen}           
+                  options={{
+                    title: "main", 
+                    /*이 title 자리에 해당 날짜 넣고 싶은데, 이 값이 drawer 젤 윗칸 이름에 그대로 들어가기도하고, 
+                    {month}/{today}를 title에 넣는 방법을 모르겠음 */
+                    headerStyle: {
+                      backgroundColor: theme.background
+                    },
+                    headerTitleStyle: {
+                      fontSize: 35,
+                      color: theme.main,
+                    },
+                    headerTitleAlign: 'center',
+                    headerTintColor: theme.main,
+                  }}
+              />
+
+              <Drawer.Screen 
+                  name="all" 
+                  component={ViewAll} 
+                  options={{
+                    headerStyle: {
+                      backgroundColor: theme.background
+                    },
+                    headerTitleStyle: {
+                      fontSize: 35,
+                      color: theme.main,
+                    },
+                    headerTitleAlign: 'center',
+                    headerTintColor: theme.main,
+                  }}
+              />
+
+              <Drawer.Screen 
+                  name="completed" 
+                  component={Completed} 
+                  options={{
+                    headerStyle: {
+                      backgroundColor: theme.background
+                    },
+                    headerTitleStyle: {
+                      fontSize: 35,
+                      color: theme.main,
+                    },
+                    headerTitleAlign: 'center',
+                    headerTintColor: theme.main,
+                  }}
+              />
+
+              <Drawer.Screen 
+                  name="uncompleted" 
+                  component={Uncompleted} 
+                  options={{
+                    headerStyle: {
+                      backgroundColor: theme.background
+                    },
+                    headerTitleStyle: {
+                      fontSize: 35,
+                      color: theme.main,
+                    },
+                    headerTitleAlign: 'center',
+                    headerTintColor: theme.main,
+                  }}
+              />
+
+              <Drawer.Screen 
+                  name="daily" 
+                  component={Daily} 
+                  options={{
+                    headerStyle: {
+                      backgroundColor: theme.background
+                    },
+                    headerTitleStyle: {
+                      fontSize: 35,
+                      color: theme.main,
+                    },
+                    headerTitleAlign: 'center',
+                    headerTintColor: theme.main,
+                  }}
+              />
+
+              <Drawer.Screen 
+                  name="monthly" 
+                  component={Monthly} 
+                  options={{
+                    headerStyle: {
+                      backgroundColor: theme.background
+                    },
+                    headerTitleStyle: {
+                      fontSize: 35,
+                      color: theme.main,
+                    },
+                    headerTitleAlign: 'center',
+                    headerTintColor: theme.main,
+                  }}
+              />
+
+              <Drawer.Screen 
+                  name="completion rate" 
+                  component={CompletionRate} 
+                  options={{
+                    headerStyle: {
+                      backgroundColor: theme.background
+                    },
+                    headerTitleStyle: {
+                      fontSize: 30,
+                      color: theme.main,
+                    },
+                    headerTitleAlign: 'center',
+                    headerTintColor: theme.main,
+                  }}
+              />
+          </Drawer.Navigator>
+  );
+}
+
 function App() {
+  /*
+   * Stack.Navigator 목록에, 1) MenuBar 2) Tab 3) SELECT 있는 것.
+   * 이때 형식이 1) Drawer, 2)Tab bar 3)은 그냥 screen.
+   */
   return (
     <NavigationContainer>
       <Stack.Navigator>
-        <Stack.Screen name="TAB" component={BottomTab} 
-           options={{headerShown:false, 
-           style: {elevation: 0, shadowOffset: {width: 0, height: 0}}, //remove line for Android, iOS
-           }}/>
-        {/*Main_Screen*/}
-        <Stack.Screen name="MAIN" component={MainScreen} 
-          options={{ headerShown: false}}/>
-        {/*Select_Screen*/}
-        <Stack.Screen name="SELECT" component={SelectScreen} 
+        <Stack.Screen 
+          name="Main" 
+          component={MenuBar} 
+          options={{
+            headerShown:false,
+           }}
+        />
+
+        <Stack.Screen 
+          name="Tab" 
+          component={BottomTab} 
+          options={{
+            headerShown:false, 
+            style: {elevation: 0, shadowOffset: {width: 0, height: 0}}, //remove line for Android, iOS
+           }}
+        />
+        
+        {/* <Stack.Screen name="MAIN" component={MainScreen} options={{ headerShown: false}}/> */}
+
+        <Stack.Screen 
+          name="SELECT" 
+          component={SelectScreen} 
           options={{
             title: 'SELECT & DELETE',
             cardstyle: {backgroundColor: theme.background},

--- a/src/MainScreen.js
+++ b/src/MainScreen.js
@@ -115,7 +115,8 @@ export default function MainScreen({navigation}) {
             <StatusBar barStyle="light-content" style={barStyles.statusbar}/>    
 
             <View style={topbarStyles.topbar}>
-                <IconButton type={images.menubar}/> 
+                <IconButton type={images.menubar} onPress={() => navigation.openDrawer()}/> 
+                {/*cf) navigation.closeDrawer(), navigation.toggleDrawer()*/}
                 <Text style={textStyles.title}> {month}/{today} </Text>
                 <Text style={textStyles.title}> Today </Text>
             </View>

--- a/src/screens/CompletedScreen.js
+++ b/src/screens/CompletedScreen.js
@@ -1,0 +1,27 @@
+/*미완료 페이지 just for testing*/
+import React, {Component} from 'react';
+import {View, Text, StyleSheet} from 'react-native';
+
+class Completed extends Component {
+    render() {
+      return (
+        <View style={styles.container}>
+            <Text style={styles.textStyle}>completed screen</Text>
+        </View>
+      );
+    }
+  }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  textStyle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});
+
+export default Completed;

--- a/src/screens/CompletionRateScreen.js
+++ b/src/screens/CompletionRateScreen.js
@@ -1,0 +1,27 @@
+/*미완료 페이지 just for testing*/
+import React, {Component} from 'react';
+import {View, Text, StyleSheet} from 'react-native';
+
+class CompletionRate extends Component {
+    render() {
+      return (
+        <View style={styles.container}>
+            <Text style={styles.textStyle}>completion rate screen</Text>
+        </View>
+      );
+    }
+  }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  textStyle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});
+
+export default CompletionRate;

--- a/src/screens/DailyScreen.js
+++ b/src/screens/DailyScreen.js
@@ -1,0 +1,27 @@
+/*미완료 페이지 just for testing*/
+import React, {Component} from 'react';
+import {View, Text, StyleSheet} from 'react-native';
+
+class Daily extends Component {
+    render() {
+      return (
+        <View style={styles.container}>
+            <Text style={styles.textStyle}>daily screen</Text>
+        </View>
+      );
+    }
+  }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  textStyle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});
+
+export default Daily;

--- a/src/screens/SelectScreen.js
+++ b/src/screens/SelectScreen.js
@@ -1,10 +1,10 @@
 import React, { useState, Component } from 'react';
 import {Button, StatusBar, SafeAreaView, Text, Dimensions, ScrollView, View} from 'react-native';
-import {viewStyles, textStyles, barStyles, cardStyles, topbarStyles} from './styles';
-import Input from './components/Input';
-import { images } from './images';
-import IconButton from './components/IconButton';
-import Task from './components/Task';
+import {viewStyles, textStyles, barStyles, cardStyles, topbarStyles} from '../styles';
+import Input from '../components/Input';
+import { images } from '../images';
+import IconButton from '../components/IconButton';
+import Task from '../components/Task';
 
 export default function SelectScreen() {
     //Issue

--- a/src/screens/UncompletedScreen.js
+++ b/src/screens/UncompletedScreen.js
@@ -1,0 +1,27 @@
+/*미완료 페이지 just for testing*/
+import React, {Component} from 'react';
+import {View, Text, StyleSheet} from 'react-native';
+
+class Uncompleted extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+          <Text style={styles.textStyle}>uncompleted screen</Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  textStyle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});
+
+export default Uncompleted;

--- a/src/screens/monthlyScreen.js
+++ b/src/screens/monthlyScreen.js
@@ -1,0 +1,27 @@
+/*미완료 페이지 just for testing*/
+import React, {Component} from 'react';
+import {View, Text, StyleSheet} from 'react-native';
+
+class Monthly extends Component {
+    render() {
+      return (
+        <View style={styles.container}>
+            <Text style={styles.textStyle}>monthly screen</Text>
+        </View>
+      );
+    }
+  }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  textStyle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});
+
+export default Monthly;


### PR DESCRIPTION
@melody2108 @tdddt @Jeong-Hyeon-Lee  

### **add: Menu Drawer & Many Pages**
**0. 모듈 설치**
- `npm install @react-navigation/drawer`

**1. Add Drawer Navigation**
- 상단에 햄버거 메뉴 추가했습니다
- 각 메뉴를 늘리고 싶거나 수정하고 싶으면 저한테 말해주세요

**2. Add many screens at 'screens folder'**
- 각 메뉴마다 screen생성해서 screens파일에 정리해두었습니다.
- 앞으로 screen은 모두 여기에 모아주세요!
 
 
 

### **추후 수정+상의해야할 사항**

- [x] 하단 tab바와 상단 drawer바의 역할 분리

   - 현재 drawer바와 tab바의 내용이 겹쳐서 tab바는 보이지 않는 것임. 내용만 안겹치면 둘다 보이게 할 수 있음.
   - 하단 tab바를 없애기로 결정함

- [x] 상단에 해당날짜를 넣기로 했는데, App.js 주석을 보면, 

   - title 자리에 해당 날짜 넣고 싶은데, 이 값이 drawer 젤 윗 칸 이름에 그대로 들어가기도하고
   - {month}/{today}를 title에 넣는 방법을 모르겠음 
   - 제목말고, 제목 한칸 밑에 넣어서 해결함

- [x] (해결완료)
나중에 발견한 오류인데, 
tab바에서는 view all누르면 완료/수정/삭제 그대로 옮겨가게 근주님이 이미 만드셨는데,
drawer바에서도 똑같이 viewAllscreen을 연결해주는 거니까 될 줄 알았는데,
연결이 안되어서 main에서 수정한거랑 따로 놀고 있음. 

- [x]  draw바에서 view all 누르면, 헤더색상 안바뀌어있음 (해결완료)